### PR TITLE
Always on top feature

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="VRCTextboxOSC.MainWindow"
+<Window x:Class="VRCTextboxOSC.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -19,6 +19,7 @@
         <Label x:Name="LblCharCount" Content="0/144" Foreground="#666666"  HorizontalContentAlignment="Right" VerticalContentAlignment="Center" HorizontalAlignment="Left" Margin="554,175,0,0" VerticalAlignment="Top" Height="28" FontSize="10" Width="75"/>
         <CheckBox x:Name="CkbxOverflow" Content="Continuous writing" HorizontalAlignment="Left" Margin="226,208,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center" Foreground="White" FontSize="15" FontFamily="Courier New" HorizontalContentAlignment="Left" Height="25" Width="186" Checked="CheckBox_Checked" Unchecked="CheckBox_Checked"/>
         <Label x:Name="LblStatus" Content="Sending to" Foreground="#777777"  HorizontalContentAlignment="Left" VerticalContentAlignment="Center" HorizontalAlignment="Left" Margin="3,-2,0,0" VerticalAlignment="Top" Height="28" FontSize="10" Width="632"/>
+        <CheckBox x:Name="alwaysontop_toggle" Content=" Set Window Always on top?" HorizontalAlignment="Left" Margin="370,0,0,0" VerticalAlignment="Top" VerticalContentAlignment="Center" Foreground="White" FontSize="15" FontFamily="Courier New" HorizontalContentAlignment="Left" Height="24" Width="259" Checked="CheckBox_Checked" Unchecked="CheckBox_Checked"/>
     </Grid>
 </Window>
     

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Timers;
 using System.Windows;
 using System.Windows.Controls;
@@ -137,6 +137,17 @@ namespace VRCTextboxOSC
         {
             if (!isEnabled)
                 return;
+
+            if (alwaysontop_toggle.IsChecked != null && (bool)alwaysontop_toggle.IsChecked)
+            {
+                Window parent = Window.GetWindow(this);
+                parent.Topmost = true;
+            }
+            else
+            {
+                Window parent = Window.GetWindow(this);
+                parent.Topmost = false;
+            }
 
             if (CkbxOverflow.IsChecked != null && (bool)CkbxOverflow.IsChecked)
             {

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ NEW:
   - Added "Set Window Always on top" mode,
   This is useful for _Desktop Users_ who want to keep the textbox app window ontop of all other apps.
 
+![always on top mode](https://user-images.githubusercontent.com/40323669/192068312-19d3b1f2-895a-4ed5-b1e5-a0627c1c7520.png)
+
 # [Download here](https://github.com/I5UCC/VRCTextboxOSC/releases/download/v0.1.1/VRCTextboxOSCv0.1.1.zip)
 
 # Showcase
@@ -29,3 +31,4 @@ Then just run the ```VRCTextboxOSC.exe``` and you are all set! <br/>
 # Requirements
 
 - [.NET 6 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0/runtime)
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ I has two modes:
   - Continuous Writing: When the maximum Character limit is reached it removes the first word so you can continue typing.
 - Manually send by pressing enter or the send button.
 
+NEW: 
+  - Added "Set Window Always on top" mode,
+  This is useful for _Desktop Users_ who want to keep the textbox app window ontop of all other apps.
+
 # [Download here](https://github.com/I5UCC/VRCTextboxOSC/releases/download/v0.1.1/VRCTextboxOSCv0.1.1.zip)
 
 # Showcase


### PR DESCRIPTION
hello,
i recently found your app and started using it in VRC.
but i soon discovered that if you are a desktop user the app would get hidden behind the vrc window (if you only have 1 monitor)
or behind other apps if you have other monitors (and tried to move it over there).
so in order to attempt to fix it, i added a small mode that allows you to toggle whether the window would be always on top of all other windows and apps or not (by ticking on or off the check box)